### PR TITLE
more tweaks + fixes

### DIFF
--- a/game/bosses.js
+++ b/game/bosses.js
@@ -715,7 +715,7 @@ NinjaGuy.prototype.update = function() {
                 this.maxSpeed = this.mSpeed_init;
                 this.acceleration = 150;
                 this.lunging = false;
-                this.lungingCD = Math.floor(Math.random() * 45) + 435;
+                this.lungingCD = Math.floor(Math.random() * 90) + 430;
             }
         }
         if (this.slash && this.anim.slash.isDone()) {
@@ -732,7 +732,7 @@ NinjaGuy.prototype.update = function() {
             this.sound.throw.load();
             this.maxSpeed = this.mSpeed_init;
             this.throw = false;
-            this.throwCD = Math.floor(Math.random() * 60) + 195;
+            this.throwCD = Math.floor(Math.random() * 90) + 240;
         }
         if (this.collideLeft() || this.collideRight()) {
             this.velocity.x = -this.velocity.x / friction;

--- a/game/environments.js
+++ b/game/environments.js
@@ -51,7 +51,7 @@ Wall.prototype.constructor = Wall;
 Wall.prototype.update = function() {
     for (var i = 0; i < this.game.entities.length; i++) {
         var ent = this.game.entities[i];
-        if ((ent.player || ent.enemy) && !ent.manager && !ent.ability) {
+        if ((ent.player || ent.enemy) && !ent.manager && !ent.ability && !ent.laser) {
             if (this.collide(ent)) {
                 if (this.side == 'left' || this.side == 'right') {
                     ent.velocity.x = 0;

--- a/game/finalboss.js
+++ b/game/finalboss.js
@@ -44,6 +44,7 @@ function Smoothie(game) {
     this.health = 1500;
     this.maxHealth = this.health;
     this.engage = true;
+    this.wall = new Wall(game, 0, 0, 1280, 100);
 
     // cooldowns
     this.knockBack = 0;
@@ -121,13 +122,15 @@ Smoothie.prototype.update = function() {
                 this.start = false;
                 this.sweep = true;
                 this.sweepCD = 120;
+                this.game.addEntity(this.wall);
             }
             if (this.sweep && this.sweepCD <= 0) {
                 this.anim.laser.sweep.elapsedTime = 0;
                 this.sweep = false;
                 this.laser = false;
-                this.laserCD = Math.floor(Math.random() * 120) + 540;
+                this.laserCD = Math.floor(Math.random() * 300) + 600;
                 this.atkCD = Math.floor(Math.random() * 30) + 60;
+                this.wall.removeFromWorld = true;
             }
         }
 
@@ -149,8 +152,8 @@ Smoothie.prototype.update = function() {
             if (ent.player && ent.alive && this.stunCD <= 0) {
                 if (this.laser) {
                     if (!this.start && !this.sweep) {
-                        if (this.x < 635 || this.x > 645 || this.y < 125 || this.y > 135) {
-                            var atan = Math.atan2(130 - this.y, 640 - this.x);
+                        if (this.x < 635 || this.x > 645 || this.y < 95 || this.y > 105) {
+                            var atan = Math.atan2(100 - this.y, 640 - this.x);
                             if (this.rotation > atan) {
                                 var rotdif = this.rotation - atan;
                                 while (rotdif > Math.PI * 2) rotdif -= Math.PI * 2;
@@ -234,6 +237,7 @@ Smoothie.prototype.update = function() {
                     if (this.laserCD <= 0 && !this.laser && !this.swipe && !this.jab && !this.puke) {
                         this.landedBlow = false;
                         this.laser = true;
+                        this.wall.removeFromWorld = false;
                     } else if (this.atkCD <= 0) {
                         if (this.swpCD <= 0 && dist < 90 && !this.laser && !this.jab && !this.puke) {
                             this.landedBlow = false;
@@ -372,7 +376,7 @@ Smoothie.prototype.hit = function(other) {
 
 function Puke(game, x, y, rot) {
     this.anim = {};
-    this.anim.move = new Animation(ASSET_MANAGER.getAsset('./img/entities/boss_puke.png'), 0, 0, 200, 200, 0.75, 1, false, false);
+    this.anim.move = new Animation(ASSET_MANAGER.getAsset('./img/entities/boss_puke.png'), 0, 0, 200, 200, 1, 1, false, false);
     this.anim.land = new Animation(ASSET_MANAGER.getAsset('./img/entities/boss_puke.png'), 0, 0, 200, 200, 0.15, 4, false, false);
     this.rotation = rot;
     this.velocity = {};
@@ -392,7 +396,7 @@ Puke.prototype.update = function() {
     if (this.move && this.anim.move.isDone()) {
         this.anim.move.elapsedTime = 0;
         this.move = false;
-        this.maxSpeed = 150;
+        this.maxSpeed = 100;
     }
     if (!this.move) {
         if (this.anim.land.isDone()) {

--- a/game/player.js
+++ b/game/player.js
@@ -161,7 +161,7 @@ Bullet.prototype.update = function() {
     for (var i = 0; i < this.game.entities.length; i++) {
         var ent = this.game.entities[i];
         if (this.collide(ent)) {
-            if (ent.enemy) {
+            if (ent.enemy && !ent.laser) {
                 ent.sound.hit3.play();
                 ent.hurt = true;
                 ent.health -= this.damage;


### PR DESCRIPTION
- gun can no longer damage Smoothie when he's using his laser
- Smoothie laser cooldown increased
- Smoothie puke flies farther before landing
- 89 throw and lunge cooldowns increased
- player now prevented from going behind Smoothie while he is using his laser